### PR TITLE
add project url to version output

### DIFF
--- a/ks
+++ b/ks
@@ -2,6 +2,7 @@
 set -euo pipefail
 IFS=$'\n\t'
 VERSION="0.4.2"
+PROJECT_URL="https://github.com/loteoo/ks"
 
 # Commands
 # ==========
@@ -176,6 +177,7 @@ EOT
 
 version () {
   echo "$VERSION"
+  echo "$PROJECT_URL"
 }
 
 completion() {


### PR DESCRIPTION
Since it's hard to remember the project URL to see if there is a new version, I added it to the `version` output:

    $ ./ks version
    0.4.2
    https://github.com/loteoo/ks
